### PR TITLE
workerでhost設定ができない問題修正

### DIFF
--- a/funnel/worker.py
+++ b/funnel/worker.py
@@ -32,8 +32,8 @@ class Worker(object):
             pass # TODO error handling
 
     def start(self, **kwargs):
-        self._queue.connect()
-        self._queue.start_consuming(self._on_message, **kwargs)
+        self._queue.connect(**kwargs)
+        self._queue.start_consuming(self._on_message, no_ack=kwargs.get('no_ack'), rpc=kwargs.get('rpc'))
 
     def get_queue_name(self):
         return self._queue.name


### PR DESCRIPTION
workerのときにhostを渡す方法が無かったので、startで渡せるようにしました。
start_consumingが変わっているのは、元々 no_ackをstartで渡していたが、hostを追加するとエラーになるので。
