### PR TITLE
Fix ready flag bug of SyncManager

### DIFF
--- a/funnel/queue.py
+++ b/funnel/queue.py
@@ -158,6 +158,7 @@ class SyncManager(BaseManager):
                 exclusive = self._exclusive,
                 durable = self._persistent
             )
+            self._ready = True
         except AMQPConnectionError as e:
             logging.exception(e)
             self.reconnect(**kwargs)

--- a/funnel/tests/queue.py
+++ b/funnel/tests/queue.py
@@ -137,6 +137,25 @@ class TestSyncManager(AsyncTestCase):
         except Exception as e:
             self.fail("This exception is raised: {}".format(e))
 
+    def test_ready_flag_when_queue_declere_completed(self):
+        queue = SyncManager(queue="dummy")
+        worker_queue = AsyncManager(queue="dummy")
+        self.addCleanup(queue.close_connection)
+        queue.connect(host=HOST)
+        worker_queue.connect(host=HOST)
+
+        def on_message():
+            pass
+
+        worker_queue.start_consuming(
+            on_message,
+        )
+
+        queue.publish({"message": "Hello, world!"}, routing_key=queue.name)
+        IOLoop.current().add_timeout(time() + 0.2, self.stop)
+        self.wait()
+        self.assertTrue(queue._ready)
+
 class TestMassage(TestCase):
     def test__prepare_body(self):
         def dummy_callback():


### PR DESCRIPTION
The self._ready of SyncManager modified to change to true if queue declare completed.
